### PR TITLE
fix error when compiling with CUDA

### DIFF
--- a/include/half.hpp
+++ b/include/half.hpp
@@ -1319,12 +1319,12 @@ namespace half_float
 			unsigned int abs = value & 0x7FFF;
 			if(abs >= 0x7C00)
 			{
-				raise(FE_INVALID);
+				detail::raise(FE_INVALID);
 				return (value&0x8000) ? std::numeric_limits<T>::min() : std::numeric_limits<T>::max();
 			}
 			if(abs < 0x3800)
 			{
-				raise(FE_INEXACT, I);
+				detail::raise(FE_INEXACT, I);
 				return	(R==std::round_toward_infinity) ? T(~(value>>15)&(abs!=0)) :
 						(R==std::round_toward_neg_infinity) ? -T(value>0x8000) :
 						T();
@@ -1337,9 +1337,9 @@ namespace half_float
 				(R==std::round_toward_neg_infinity) ? (((1<<exp)-1)&-(value>>15)) : 0))>>exp));
 			if((!std::numeric_limits<T>::is_signed && (value&0x8000)) || (std::numeric_limits<T>::digits<16 &&
 				((value&0x8000) ? (-i<std::numeric_limits<T>::min()) : (i>std::numeric_limits<T>::max()))))
-				raise(FE_INVALID);
+				detail::raise(FE_INVALID);
 			else if(I && exp > 0 && (m&((1<<exp)-1)))
-				raise(FE_INEXACT);
+				detail::raise(FE_INEXACT);
 			return static_cast<T>((value&0x8000) ? -i : i);
 		}
 


### PR DESCRIPTION
add namespace for `raise` to fix error when compiling with CUDA
```
[  9%] Building NVCC (Device) object CMakeFiles/of_ccobj.dir/oneflow/core/kernel/of_ccobj_generated_random_generator.cu.o
/oneflow_src/build-conda/3rd-install/half/include/half.hpp(1322): error: more than one instance of function "half_float::detail::raise" matches the argument list:
            function "raise(int)"
            function "half_float::detail::raise(int, __nv_bool)"
            argument types are: (enum <unnamed>)/oneflow_src/build-conda/3rd-install/half/include/half.hpp(1340): error: more than one instance of function "half_float::detail::raise" matches the argument list:
            function "raise(int)"
            function "half_float::detail::raise(int, __nv_bool)"
            argument types are: (enum <unnamed>)/oneflow_src/build-conda/3rd-install/half/include/half.hpp(1342): error: more than one instance of function "half_float::detail::raise" matches the argument list:
            function "raise(int)"
            function "half_float::detail::raise(int, __nv_bool)"
            argument types are: (enum <unnamed>)3 errors detected in the compilation of "/tmp/tmpxft_00000bbf_00000000-9_random_generator.compute_75.cpp1.ii".
CMake Error at of_ccobj_generated_random_generator.cu.o.cmake:279 (message):
  Error generating file
  /oneflow_src/build-conda/CMakeFiles/of_ccobj.dir/oneflow/core/kernel/./of_ccobj_generated_random_generator.cu.omake[2]: *** [CMakeFiles/of_ccobj.dir/build.make:20179: CMakeFiles/of_ccobj.dir/oneflow/core/kernel/of_ccobj_generated_random_generator.cu.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:356: CMakeFiles/of_ccobj.dir/all] Error 2
make: *** [Makefile:95: all] Error 2
```